### PR TITLE
Fix typo in comment for leave

### DIFF
--- a/src/srep/ui.scm
+++ b/src/srep/ui.scm
@@ -50,7 +50,7 @@ There is NO WARRANTY, to the extent permitted by law.~%"
   (exit 0))
 
 (define (leave format-string . args)
-  "Display error message and exist."
+  "Display error message and exit."
   (apply format (current-error-port) format-string args)
   (newline)
   (exit 1))


### PR DESCRIPTION
## Summary
- correct the comment in `leave` to say "exit" instead of "exist"

## Testing
- `grep -R "error message and exist" -n || true`